### PR TITLE
change package name

### DIFF
--- a/mitosheet_helper_config/mito_config.py
+++ b/mitosheet_helper_config/mito_config.py
@@ -18,7 +18,7 @@ MITO_ENTERPRISE_CONFIGURATION: Dict[str, Any] = {
 	# users will get directed to the Mito community slack. The final result should look like:
 	# 	
 	# 	SUPPORT_EMAIL: 'mito_support@company.com',
-	SUPPORT_EMAIL: None, 
+	SUPPORT_EMAIL: 'aaron@sagacollab.com', 
 }
 
 # Ensure that the MEC_VERSION was not changed.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 
 [project]
-name = "mitosheet_helper_config"
+name = "mitosheet_helper_config_2"
 version = "0.0.1"
 authors = [
   { name="Aaron Diamond-Reivich", email="aarondr77@gmail.com" },


### PR DESCRIPTION
# Description

This tests that changing the package name still allows us to import the package as `mitosheet_helper_config`

# Testing

1. Launch a mitosheet in a virtual environment
2. Make sure you don't already have a mitosheet_helper_config package downloaded
3. pip install -i https://test.pypi.org/simple/ mitosheet-helper-config-2==0.0.1
4. Try using the Get Support button and see that it opens an email to aaron@sagacollab.com


# Documentation

Note if any new documentation needs to addressed or reviewed.